### PR TITLE
fix: add break protection to prevent blocking creative-placed block b…

### DIFF
--- a/src/main/java/fr/k0bus/creativemanager/event/PlayerBreak.java
+++ b/src/main/java/fr/k0bus/creativemanager/event/PlayerBreak.java
@@ -82,6 +82,7 @@ public class PlayerBreak implements Listener {
 					BlockLog blockLog = plugin.getDataManager().getBlockFrom(block.getLocation());
 					if (blockLog != null) {
 						if (blockLog.isCreative()) {
+							if (!CreativeManager.getSettings().getProtection(Protections.BREAK)) continue;
 							e.setCancelled(true);
 							return;
 						}

--- a/src/main/java/fr/k0bus/creativemanager/log/DataManager.java
+++ b/src/main/java/fr/k0bus/creativemanager/log/DataManager.java
@@ -1,206 +1,208 @@
 package fr.k0bus.creativemanager.log;
 
 import fr.k0bus.creativemanager.CreativeManager;
+import java.io.File;
+import java.io.IOException;
+import java.sql.*;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.*;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-
 public class DataManager {
 
-    Connection conn;
-    final String dbname;
-    final HashMap<Location, BlockLog> blockLogHashMap;
-    final CreativeManager plugin;
+  Connection conn;
+  final String dbname;
+  final ConcurrentHashMap<Location, BlockLog> blockLogHashMap;
+  final CreativeManager plugin;
 
-    public DataManager(String dbname, CreativeManager plugin)
-    {
-        this.blockLogHashMap = new HashMap<>();
-        this.dbname = dbname;
-        this.plugin = plugin;
-        this.conn = startConnection();
-        init();
-        load();
-    }
+  public DataManager(String dbname, CreativeManager plugin) {
+    this.blockLogHashMap = new ConcurrentHashMap<>();
+    this.dbname = dbname;
+    this.plugin = plugin;
+    this.conn = startConnection();
+    init();
+    load();
+  }
 
-    public BlockLog getBlockFrom(Location location)
-    {
-        return blockLogHashMap.get(location);
-    }
+  public BlockLog getBlockFrom(Location location) {
+    return blockLogHashMap.get(location);
+  }
 
-    public void moveBlock(Location from, Location to)
-    {
-        if(blockLogHashMap.containsKey(from))
-        {
-            BlockLog blockLog = blockLogHashMap.get(from);
-            blockLog.setLocation(to);
-            blockLogHashMap.put(to, blockLog);
-            blockLogHashMap.remove(from);
-        }
+  public void moveBlock(Location from, Location to) {
+    if (blockLogHashMap.containsKey(from)) {
+      BlockLog blockLog = blockLogHashMap.get(from);
+      blockLog.setLocation(to);
+      blockLogHashMap.put(to, blockLog);
+      blockLogHashMap.remove(from);
     }
-    public void removeBlock(Location location)
-    {
-        BlockLog blockLog = blockLogHashMap.get(location);
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> delete(blockLog));
-        blockLogHashMap.remove(location);
-    }
+  }
 
-    public void addBlock(BlockLog log)
-    {
-        blockLogHashMap.put(log.getLocation(), log);
-    }
+  public void removeBlock(Location location) {
+    BlockLog blockLog = blockLogHashMap.get(location);
+    Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> delete(blockLog));
+    blockLogHashMap.remove(location);
+  }
 
-    public void saveAsync()
-    {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, this::save);
-    }
-    public void save()
-    {
-        int n = 0;
-        ConcurrentHashMap<Location, BlockLog> cloned = new ConcurrentHashMap<>(blockLogHashMap);
-        for (Map.Entry<Location, BlockLog> val: cloned.entrySet()) {
-            if(val.getValue().isSaved()) continue;
-            saveAsync(val.getValue());
-            n++;
-        }
-        if(n>0)
-            plugin.getLog().log("&2Log saved to database ! &7[" + n + "]");
-    }
+  public void addBlock(BlockLog log) {
+    blockLogHashMap.put(log.getLocation(), log);
+  }
 
-    public void delete(BlockLog log)
-    {
-        if(log != null)
-            try {
-                PreparedStatement ps = conn.prepareStatement("DELETE FROM block_log WHERE uuid=?");
-                ps.setString(1, log.getUuid().toString());
-                ps.executeUpdate();
-                ps.close();
-            } catch (SQLException ex) {
-                Bukkit.getLogger().log(Level.SEVERE, "Unable to retrieve connection", ex);
-            }
-    }
-    public void saveAsync(BlockLog log)
-    {
-        if(log.getLocation().getWorld() == null){
-            delete(log);
-            return;
-        }
-        PreparedStatement ps = null;
-        try {
-            ps = conn.prepareStatement("REPLACE INTO block_log (uuid,world,x,y, z, player) VALUES(?,?,?,?,?,?)");
-            ps.setString(1, log.getUuid().toString());
-            ps.setString(2, log.getLocation().getWorld().getName());
-            ps.setInt(3, log.getLocation().getBlockX());
-            ps.setInt(4, log.getLocation().getBlockY());
-            ps.setInt(5, log.getLocation().getBlockZ());
-            ps.setString(6, log.getPlayer().getUniqueId().toString());
-            ps.executeUpdate();
-            if(blockLogHashMap.containsKey(log.getLocation()))
-                blockLogHashMap.get(log.getLocation()).setSaved(true);
-        } catch (SQLException ex) {
-            Bukkit.getLogger().log(Level.SEVERE, ex.toString());
-        } finally {
-            try {
-                if (ps != null)
-                    ps.close();
-            } catch (SQLException ex) {
-                Bukkit.getLogger().log(Level.SEVERE, ex.toString());
-            }
-        }
-    }
+  public void saveAsync() {
+    Bukkit.getScheduler().runTaskAsynchronously(plugin, this::save);
+  }
 
-    public Connection startConnection() {
-        if (this.conn != null)
-            return this.conn;
-        File dataFolder = new File(plugin.getDataFolder(), this.dbname + ".db");
-        if (!dataFolder.exists())
-            try {
-                boolean ignored = dataFolder.createNewFile();
-            } catch (IOException e) {
-                Bukkit.getLogger().log(Level.SEVERE, "File write error: " + this.dbname + ".db");
-            }
-        try {
-            Class.forName("org.sqlite.JDBC");
-            return DriverManager.getConnection("jdbc:sqlite:" + dataFolder);
-        } catch (SQLException ex) {
-            Bukkit.getLogger().log(Level.SEVERE, "SQLite exception on initialize");
-            Bukkit.getLogger().log(Level.SEVERE, ex.toString());
-        } catch (ClassNotFoundException ex) {
-            Bukkit.getLogger().log(Level.SEVERE, "You need the SQLite JBDC library. Google it. Put it in /lib folder.");
-        }
-        return null;
+  public void save() {
+    int n = 0;
+    ConcurrentHashMap<Location, BlockLog> cloned = new ConcurrentHashMap<>(blockLogHashMap);
+    for (Map.Entry<Location, BlockLog> val : cloned.entrySet()) {
+      if (val.getValue().isSaved()) continue;
+      saveAsync(val.getValue());
+      n++;
     }
-    public void init() {
-        try {
-            this.conn = startConnection();
-            Statement s = this.conn.createStatement();
-            // Create table if not exist
-            s.executeUpdate("CREATE TABLE IF NOT EXISTS block_log (`uuid` text NOT NULL,`world` text NOT NULL,`x` int NOT NULL,`y` int NOT NULL,`z` int NOT NULL,`player` text NOT NULL,PRIMARY KEY(`uuid`));");
-            // Update table if exist
-            s.close();
-        } catch (SQLException e) {
-            plugin.getLogger().log(Level.SEVERE, "SQL ERROR", e);
-        }
-    }
+    if (n > 0) plugin.getLog().log("&2Log saved to database ! &7[" + n + "]");
+  }
 
-    private void load()
-    {
-        try {
-            PreparedStatement ps = conn.prepareStatement("SELECT * FROM block_log");
-            ResultSet rs = ps.executeQuery();
-            while (rs.next()) {
-                OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(rs.getString("player")));
-                Location location = new Location(Bukkit.getWorld(rs.getString("world")),
-                        rs.getInt("x"),
-                        rs.getInt("y"),
-                        rs.getInt("z"));
-                UUID uuid = UUID.fromString(rs.getString("uuid"));
-                BlockLog loaded = new BlockLog(location, player, uuid);
-                loaded.setSaved(true);
-                blockLogHashMap.put(location, loaded);
-            }
-            ps.close();
-            rs.close();
-        } catch (SQLException ex) {
-            Bukkit.getLogger().log(Level.SEVERE, "Unable to retrieve connection", ex);
-        }
-    }
+  public void delete(BlockLog log) {
+    if (log != null)
+      try {
+        PreparedStatement ps = conn.prepareStatement("DELETE FROM block_log WHERE uuid=?");
+        ps.setString(1, log.getUuid().toString());
+        ps.executeUpdate();
+        ps.close();
+      } catch (SQLException ex) {
+        Bukkit.getLogger().log(Level.SEVERE, "Unable to retrieve connection", ex);
+      }
+  }
 
-    public void load(World world)
-    {
-        try {
-            PreparedStatement ps = conn.prepareStatement(
-                    "SELECT * FROM block_log WHERE world= '" + world.getName() + "'"
-            );
-            ResultSet rs = ps.executeQuery();
-            while (rs.next()) {
-                OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(rs.getString("player")));
-                Location location = new Location(Bukkit.getWorld(rs.getString("world")),
-                        rs.getInt("x"),
-                        rs.getInt("y"),
-                        rs.getInt("z"));
-                UUID uuid = UUID.fromString(rs.getString("uuid"));
-                BlockLog loaded = new BlockLog(location, player, uuid);
-                loaded.setSaved(true);
-                blockLogHashMap.put(location, loaded);
-            }
-            ps.close();
-            rs.close();
-        } catch (SQLException ex) {
-            Bukkit.getLogger().log(Level.SEVERE, "Unable to retrieve connection", ex);
-        }
+  public void saveAsync(BlockLog log) {
+    if (log.getLocation().getWorld() == null) {
+      delete(log);
+      return;
     }
+    PreparedStatement ps = null;
+    try {
+      ps =
+          conn.prepareStatement(
+              "REPLACE INTO block_log (uuid,world,x,y, z, player) VALUES(?,?,?,?,?,?)");
+      ps.setString(1, log.getUuid().toString());
+      ps.setString(2, log.getLocation().getWorld().getName());
+      ps.setInt(3, log.getLocation().getBlockX());
+      ps.setInt(4, log.getLocation().getBlockY());
+      ps.setInt(5, log.getLocation().getBlockZ());
+      ps.setString(6, log.getPlayer().getUniqueId().toString());
+      ps.executeUpdate();
+      if (blockLogHashMap.containsKey(log.getLocation()))
+        blockLogHashMap.get(log.getLocation()).setSaved(true);
+    } catch (SQLException ex) {
+      Bukkit.getLogger().log(Level.SEVERE, ex.toString());
+    } finally {
+      try {
+        if (ps != null) ps.close();
+      } catch (SQLException ex) {
+        Bukkit.getLogger().log(Level.SEVERE, ex.toString());
+      }
+    }
+  }
 
-    public HashMap<Location, BlockLog> getBlockLogHashMap() {
-        return blockLogHashMap;
+  public Connection startConnection() {
+    if (this.conn != null) return this.conn;
+    File dataFolder = new File(plugin.getDataFolder(), this.dbname + ".db");
+    if (!dataFolder.exists())
+      try {
+        @SuppressWarnings("unused")
+        boolean ignored = dataFolder.createNewFile();
+      } catch (IOException e) {
+        Bukkit.getLogger().log(Level.SEVERE, "File write error: " + this.dbname + ".db");
+      }
+    try {
+      Class.forName("org.sqlite.JDBC");
+      return DriverManager.getConnection("jdbc:sqlite:" + dataFolder);
+    } catch (SQLException ex) {
+      Bukkit.getLogger().log(Level.SEVERE, "SQLite exception on initialize");
+      Bukkit.getLogger().log(Level.SEVERE, ex.toString());
+    } catch (ClassNotFoundException ex) {
+      Bukkit.getLogger()
+          .log(Level.SEVERE, "You need the SQLite JBDC library. Google it. Put it in /lib folder.");
     }
+    return null;
+  }
+
+  public void init() {
+    try {
+      this.conn = startConnection();
+      Statement s = this.conn.createStatement();
+      // Create table if not exist
+      s.executeUpdate(
+          "CREATE TABLE IF NOT EXISTS block_log ("
+              + "`uuid` text NOT NULL,"
+              + "`world` text NOT NULL,"
+              + "`x` int NOT NULL,"
+              + "`y` int NOT NULL,"
+              + "`z` int NOT NULL,"
+              + "`player` text NOT NULL,"
+              + "PRIMARY KEY(`uuid`));");
+      // Update table if exist
+      s.close();
+    } catch (SQLException e) {
+      plugin.getLogger().log(Level.SEVERE, "SQL ERROR", e);
+    }
+  }
+
+  private void load() {
+    try {
+      PreparedStatement ps = conn.prepareStatement("SELECT * FROM block_log");
+      ResultSet rs = ps.executeQuery();
+      while (rs.next()) {
+        OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(rs.getString("player")));
+        Location location =
+            new Location(
+                Bukkit.getWorld(rs.getString("world")),
+                rs.getInt("x"),
+                rs.getInt("y"),
+                rs.getInt("z"));
+        UUID uuid = UUID.fromString(rs.getString("uuid"));
+        BlockLog loaded = new BlockLog(location, player, uuid);
+        loaded.setSaved(true);
+        blockLogHashMap.put(location, loaded);
+      }
+      ps.close();
+      rs.close();
+    } catch (SQLException ex) {
+      Bukkit.getLogger().log(Level.SEVERE, "Unable to retrieve connection", ex);
+    }
+  }
+
+  public void load(World world) {
+    try {
+      PreparedStatement ps =
+          conn.prepareStatement("SELECT * FROM block_log WHERE world= '" + world.getName() + "'");
+      ResultSet rs = ps.executeQuery();
+      while (rs.next()) {
+        OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(rs.getString("player")));
+        Location location =
+            new Location(
+                Bukkit.getWorld(rs.getString("world")),
+                rs.getInt("x"),
+                rs.getInt("y"),
+                rs.getInt("z"));
+        UUID uuid = UUID.fromString(rs.getString("uuid"));
+        BlockLog loaded = new BlockLog(location, player, uuid);
+        loaded.setSaved(true);
+        blockLogHashMap.put(location, loaded);
+      }
+      ps.close();
+      rs.close();
+    } catch (SQLException ex) {
+      Bukkit.getLogger().log(Level.SEVERE, "Unable to retrieve connection", ex);
+    }
+  }
+
+  public ConcurrentHashMap<Location, BlockLog> getBlockLogHashMap() {
+    return blockLogHashMap;
+  }
 }

--- a/src/main/java/fr/k0bus/creativemanager/settings/Protections.java
+++ b/src/main/java/fr/k0bus/creativemanager/settings/Protections.java
@@ -38,7 +38,8 @@ public enum Protections {
     ARMOR("armor", Material.CHAINMAIL_HELMET, "Set a defined player armor set", "Creative Armor"),
     PL_ITEMSADDER("itemsadder", Material.REDSTONE_BLOCK, "Deny player to use itemsadder features", "ItemsAdder"),
     BUILD_CONTAINER("build-container", Material.CHEST, "Deny player to place block with items in inventory", "Place container"),
-    REMOVE_EFFECTS("remove-effects", Material.POTION, "Remove all potion effect when player switch gamemode", "Remove effects");
+    REMOVE_EFFECTS("remove-effects", Material.POTION, "Remove all potion effect when player switch gamemode", "Remove effects"),
+    BREAK("break", Material.BARRIER, "Deny survival player to break creative placed blocks", "Break Creative Block");
 
     private final String name;
     private final Material icon;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,6 +29,7 @@ protections:
   armor: false
   build-container: true #Bypass : creativemanager.bypass.build-container
   remove-effects: false
+  break: true # Deny survival players from breaking blocks placed in creative mode. Bypass: creativemanager.bypass.break-creative
   itemsadder: true
   plugins:
     citizens: true


### PR DESCRIPTION
…reaks

Added BREAK protection to Protections enum and checkLog listener. Previously, survival players were always blocked from breaking creative-placed blocks regardless of the loot setting. Now controlled via protections.break in config.yml (default: true).